### PR TITLE
Stop labelling data with the name of the Rapid Pro source instance

### DIFF
--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -77,19 +77,6 @@ def fetch_from_rapid_pro(user, google_cloud_credentials_file_path, raw_data_dir,
         traced_runs = rapid_pro.convert_runs_to_traced_data(
             user, raw_runs, raw_contacts, phone_number_uuid_table, rapid_pro_source.test_contact_uuids)
 
-        if flow in rapid_pro_source.activation_flow_names:
-            # Append the Rapid Pro source name to each run.
-            # Only do this for activation flows because this is the only place where this is interesting.
-            # Also, demogs may come from either instance, which causes problems downstream.
-            for td in traced_runs:
-                td.append_data({
-                    "source_raw": rapid_pro_source.source_name,
-                    "source_coded": CleaningUtils.make_label_from_cleaner_code(
-                        CodeSchemes.SOURCE, CodeSchemes.SOURCE.get_code_with_match_value(rapid_pro_source.source_name),
-                        Metadata.get_call_location()
-                    ).to_dict()
-                }, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
-
         log.info(f"Saving {len(raw_runs)} raw runs to {raw_runs_path}...")
         with open(raw_runs_path, "w") as raw_runs_file:
             json.dump([run.serialize() for run in raw_runs], raw_runs_file)

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -175,7 +175,7 @@ class RawDataSource(ABC):
 
 
 class RapidProSource(RawDataSource):
-    def __init__(self, source_name, domain, token_file_url, contacts_file_name, activation_flow_names,
+    def __init__(self, domain, token_file_url, contacts_file_name, activation_flow_names,
                  survey_flow_names, test_contact_uuids):
         """
         :param domain: URL of the Rapid Pro server to download data from.
@@ -193,7 +193,6 @@ class RapidProSource(RawDataSource):
                                    and dropped when the pipeline is run with "FilterTestMessages" set to true.
         :type test_contact_uuids: list of str
         """
-        self.source_name = source_name
         self.domain = domain
         self.token_file_url = token_file_url
         self.contacts_file_name = contacts_file_name
@@ -211,7 +210,6 @@ class RapidProSource(RawDataSource):
 
     @classmethod
     def from_configuration_dict(cls, configuration_dict):
-        source_name = configuration_dict["SourceName"]
         domain = configuration_dict["Domain"]
         token_file_url = configuration_dict["TokenFileURL"]
         contacts_file_name = configuration_dict["ContactsFileName"]
@@ -219,11 +217,10 @@ class RapidProSource(RawDataSource):
         survey_flow_names = configuration_dict.get("SurveyFlowNames", [])
         test_contact_uuids = configuration_dict.get("TestContactUUIDs", [])
 
-        return cls(source_name, domain, token_file_url, contacts_file_name, activation_flow_names,
+        return cls(domain, token_file_url, contacts_file_name, activation_flow_names,
                    survey_flow_names, test_contact_uuids)
 
     def validate(self):
-        validators.validate_string(self.source_name, "source_name")
         validators.validate_string(self.domain, "domain")
         validators.validate_string(self.token_file_url, "token_file_url")
         validators.validate_string(self.contacts_file_name, "contacts_file_name")


### PR DESCRIPTION
We needed this for KE-Urban, but that was a special case that we don't need here.